### PR TITLE
Set default spawn for new players

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ tasks {
     }
 
     runServer {
-        minecraftVersion("1.20.1")
+        minecraftVersion("1.20.4")
     }
 
     shadowJar {

--- a/src/main/java/de/theshadowsdust/ultimatespawn/configuration/Configuration.java
+++ b/src/main/java/de/theshadowsdust/ultimatespawn/configuration/Configuration.java
@@ -10,20 +10,22 @@ public final class Configuration {
     private String language;
     private boolean joinAtSpawn;
     private boolean respawnAtSpawn;
-
+    private boolean firstJoinSpawn;
     private String pluginVersion;
 
     public Configuration(String pluginVersion) {
-        this(Locale.getDefault().toString(), true, true, pluginVersion);
+        this(Locale.getDefault().toString(), true, true, true, pluginVersion);
     }
 
     public Configuration(@NotNull String language,
                          boolean joinAtSpawn,
                          boolean respawnAtSpawn,
+                         boolean firstJoinSpawn,
                          @NotNull String pluginVersion) {
         this.language = language;
         this.joinAtSpawn = joinAtSpawn;
         this.respawnAtSpawn = respawnAtSpawn;
+        this.firstJoinSpawn = firstJoinSpawn;
         this.pluginVersion = pluginVersion;
     }
 
@@ -52,6 +54,10 @@ public final class Configuration {
         this.respawnAtSpawn = respawnAtSpawn;
     }
 
+    public boolean isFirstJoinSpawn() { return firstJoinSpawn; }
+
+    public void setFirstJoinSpawn(boolean firstJoinSpawn) { this.firstJoinSpawn = firstJoinSpawn; }
+
     @NotNull
     public String getPluginVersion() {
         return pluginVersion;
@@ -68,25 +74,20 @@ public final class Configuration {
                 ", overrideSpawnLocation=" + joinAtSpawn +
                 ", overrideRespawnLocation=" + respawnAtSpawn +
                 ", pluginVersion='" + pluginVersion + '\'' +
+                ", firstJoinSpawn='" + firstJoinSpawn + '\'' +
                 '}';
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Configuration that)) return false;
-        if (joinAtSpawn != that.joinAtSpawn) return false;
-        if (respawnAtSpawn != that.respawnAtSpawn) return false;
-        if (!Objects.equals(language, that.language)) return false;
-        return Objects.equals(pluginVersion, that.pluginVersion);
+        if (o == null || getClass() != o.getClass()) return false;
+        Configuration that = (Configuration) o;
+        return joinAtSpawn == that.joinAtSpawn && respawnAtSpawn == that.respawnAtSpawn && firstJoinSpawn == that.firstJoinSpawn && Objects.equals(language, that.language) && Objects.equals(pluginVersion, that.pluginVersion);
     }
 
     @Override
     public int hashCode() {
-        int result = language != null ? language.hashCode() : 0;
-        result = 31 * result + (joinAtSpawn ? 1 : 0);
-        result = 31 * result + (respawnAtSpawn ? 1 : 0);
-        result = 31 * result + (pluginVersion != null ? pluginVersion.hashCode() : 0);
-        return result;
+        return Objects.hash(language, joinAtSpawn, respawnAtSpawn, firstJoinSpawn, pluginVersion);
     }
 }

--- a/src/main/java/de/theshadowsdust/ultimatespawn/listener/SpawnLocationListener.java
+++ b/src/main/java/de/theshadowsdust/ultimatespawn/listener/SpawnLocationListener.java
@@ -4,11 +4,13 @@ import de.theshadowsdust.ultimatespawn.position.SpawnPosition;
 import de.theshadowsdust.ultimatespawn.position.WrappedLocation;
 import de.theshadowsdust.ultimatespawn.UltimateSpawnPlugin;
 import org.bukkit.Location;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.spigotmc.event.player.PlayerSpawnLocationEvent;
 
 import java.util.concurrent.ExecutionException;
@@ -24,12 +26,15 @@ public final class SpawnLocationListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void handlePlayerSpawnLocation(PlayerSpawnLocationEvent event) {
+        Player player = event.getPlayer();
         try {
-            if (this.plugin.getConfigurationService().getConfig().isJoinAtSpawn()) {
-                SpawnPosition spawnPosition = this.plugin.getSpawnPositionService().getDefaultSpawn().get();
-                Location location = WrappedLocation.toLocation(spawnPosition.getWrappedLocation());
-                if (location == null) return;
-                event.setSpawnLocation(location);
+            if(!player.hasPlayedBefore()) {
+                event.setSpawnLocation(player.getWorld().getSpawnLocation());
+            }
+            else {
+                if (this.plugin.getConfigurationService().getConfig().isJoinAtSpawn()) {
+                   getLocation();
+                }
             }
         } catch (ExecutionException | InterruptedException e) {
             this.plugin.getLogger().log(Level.SEVERE, "Cannot set spawn location", e);
@@ -41,8 +46,7 @@ public final class SpawnLocationListener implements Listener {
     public void handlePlayerRespawnLocation(PlayerRespawnEvent event) {
         if (!this.plugin.getConfigurationService().getConfig().isRespawnAtSpawn()) return;
         try {
-            SpawnPosition spawnPosition = this.plugin.getSpawnPositionService().getDefaultSpawn().get();
-            Location location = WrappedLocation.toLocation(spawnPosition.getWrappedLocation());
+            Location location = getLocation();
             if (location == null) return;
             event.setRespawnLocation(location);
         } catch (ExecutionException | InterruptedException e) {
@@ -51,4 +55,10 @@ public final class SpawnLocationListener implements Listener {
             Thread.currentThread().interrupt();
         }
     }
+
+    private @Nullable Location getLocation() throws InterruptedException, ExecutionException {
+        SpawnPosition spawnPosition = this.plugin.getSpawnPositionService().getDefaultSpawn().get();
+        return WrappedLocation.toLocation(spawnPosition.getWrappedLocation());
+    }
+
 }

--- a/src/main/java/de/theshadowsdust/ultimatespawn/listener/SpawnLocationListener.java
+++ b/src/main/java/de/theshadowsdust/ultimatespawn/listener/SpawnLocationListener.java
@@ -1,5 +1,6 @@
 package de.theshadowsdust.ultimatespawn.listener;
 
+import de.theshadowsdust.ultimatespawn.configuration.Configuration;
 import de.theshadowsdust.ultimatespawn.position.SpawnPosition;
 import de.theshadowsdust.ultimatespawn.position.WrappedLocation;
 import de.theshadowsdust.ultimatespawn.UltimateSpawnPlugin;
@@ -20,6 +21,7 @@ public final class SpawnLocationListener implements Listener {
 
     private final UltimateSpawnPlugin plugin;
 
+
     public SpawnLocationListener(@NotNull UltimateSpawnPlugin plugin) {
         this.plugin = plugin;
     }
@@ -28,8 +30,9 @@ public final class SpawnLocationListener implements Listener {
     public void handlePlayerSpawnLocation(PlayerSpawnLocationEvent event) {
         Player player = event.getPlayer();
         try {
-            if(!player.hasPlayedBefore()) {
-                event.setSpawnLocation(player.getWorld().getSpawnLocation());
+            if(!player.hasPlayedBefore() && plugin.getConfigurationService().getConfig().isFirstJoinSpawn()) {
+                if(getLocation() == null) return;
+                event.setSpawnLocation(getLocation());
             }
             else {
                 if (this.plugin.getConfigurationService().getConfig().isJoinAtSpawn()) {


### PR DESCRIPTION
### Proposed changes
This PR should fix the issue new players have with joining on our spawn. After setting a default spawn, the players join there, overriding the paper heightmap algorithm that spawns them on top of our spawn on the roof.

### Wanted result (below the roof)
![grafik](https://github.com/OneLiteFeatherNET/UltimateSpawn/assets/77929075/c9b7d1dd-b647-4564-bc0f-d88aaedbef8d)

### Types of changes
Deduplication of the Location on the event, also look out for players that join the first time and update runServer to run 1.20.4

### What types of changes does your code introduce to this project?
Put an x in the boxes that apply

[ ] Bugfix (non-breaking change which fixes an issue)
[x] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
[ ] Documentation Update (if none of the other choices apply)
